### PR TITLE
Update QOwnNotes.profile

### DIFF
--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -49,6 +49,6 @@ tracelog
 disable-mnt
 private-bin gio,QOwnNotes
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,nsswitch.conf,pki,pulse,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-tmp
 


### PR DESCRIPTION
Fix startup problem in Ubuntu 19.10:

"bus[17]: D-Bus library appears to be incorrectly set up: see the manual page for dbus-uuidgen to correct this issue. (Failed to open "/var/lib/dbus/machine-id": Datei oder Verzeichnis nicht gefunden; Failed to open "/etc/machine-id": Datei oder Verzeichnis nicht gefunden)
  D-Bus not built with -rdynamic so unable to print a backtrace"


If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.

If you make a PR for new profiles or changeing profiles please do the following:
 - The ordering of options follow the rules descripted in [/usr/share/doc/firejail/profile.template](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).  
   > Hint: The profile-template is very new, if you install firejail with your package-manager, it maybe missing, therefore, and to follow the latest rules, it is recommended to use the template from the repository.
 - Order the arguments of options alphabetical, you can easy do this with the [sort.py](https://github.com/netblue30/firejail/tree/master/contrib/sort.py).  
 The path to it depends on your distro:

   | Distro | Path |
   | ------ | ---- |
   | Arch/Fedora | `/usr/lib64/firejail/sort.py` |
   | Debian/Ubuntu/Mint | `/usr/lib/x86_64-linux-gnu/firejail/sort.py` |
   | local git clone | `contrib/sort.py` |

   Note also that the sort.py script exists only since firejail `0.9.61`.

See also [CONTRIBUTING.md](/CONTRIBUTING.md).
